### PR TITLE
Count validation examples

### DIFF
--- a/ctlearn/data_loading.py
+++ b/ctlearn/data_loading.py
@@ -195,7 +195,7 @@ class HDF5DataLoader(DataLoader):
         self.num_images_before_cuts = {}
 
         self.num_events_before_cuts_by_class_name = {}
-        self.num_images_before_cuts_by_class_name = {}
+        self.num_images_before_cuts_by_tel_and_class_name = {}
 
         self.num_position_coordinates = 3
         self.telescope_positions = {}
@@ -324,8 +324,8 @@ class HDF5DataLoader(DataLoader):
                     self.num_images_before_cuts[tel_type] = 0
                 if not tel_type in self.images:
                     self.images[tel_type] = []
-                if not tel_type in self.num_images_before_cuts_by_class_name:
-                    self.num_images_before_cuts_by_class_name[tel_type] = {}
+                if not tel_type in self.num_images_before_cuts_by_tel_and_class_name:
+                    self.num_images_before_cuts_by_tel_and_class_name[tel_type] = {}
                 
                 # for each image index associated to this event
                 for tel_id, image_index in zip(tel_ids, indices):
@@ -335,9 +335,9 @@ class HDF5DataLoader(DataLoader):
                     if image_index != 0:
                         self.images[tel_type].append((row['run_number'], row['event_number'], tel_id))
                         self.num_images_before_cuts[tel_type] += 1
-                        if class_name not in self.num_images_before_cuts_by_class_name[tel_type]:
-                            self.num_images_before_cuts_by_class_name[tel_type][class_name] = 0
-                        self.num_images_before_cuts_by_class_name[tel_type][class_name] += 1
+                        if class_name not in self.num_images_before_cuts_by_tel_and_class_name[tel_type]:
+                            self.num_images_before_cuts_by_tel_and_class_name[tel_type][class_name] = 0
+                        self.num_images_before_cuts_by_tel_and_class_name[tel_type][class_name] += 1
     
     def _update_min_max_charge_values(self, filename):
         # get file handle
@@ -375,7 +375,7 @@ class HDF5DataLoader(DataLoader):
                 'num_selected_telescopes': {tel_type: len(tel_ids) for
                     tel_type, tel_ids in self.selected_telescopes.items()},
                 'num_events_before_cuts_by_class_name': self.num_events_before_cuts_by_class_name,
-                'num_images_before_cuts_by_class_name': self.num_images_before_cuts_by_class_name,
+                'num_images_before_cuts_by_tel_and_class_name': self.num_images_before_cuts_by_tel_and_class_name,
                 'num_events_after_cuts_by_class_name' : self.num_passing_events_by_class_name,
                 'num_images_after_cuts_by_class_name' : self.num_passing_images_by_class_name,
                 'num_position_coordinates': self.num_position_coordinates,

--- a/ctlearn/data_loading.py
+++ b/ctlearn/data_loading.py
@@ -586,16 +586,18 @@ class HDF5DataLoader(DataLoader):
                 
                 # If example_type is single_tel, there will 
                 # be only a single selected telescope type
-                if self.example_type == "single_tel":
-                    image_indices = row[tel_type + "_indices"]
-                    for tel_id in self.selected_telescopes[tel_type]:
-                        index = self.total_telescopes[tel_type].index(tel_id)
-                        if image_indices[index] != 0:
+                
+                image_indices = row[tel_type + "_indices"]
+                for tel_id in self.selected_telescopes[tel_type]:
+                    index = self.total_telescopes[tel_type].index(tel_id)
+                    if image_indices[index] != 0:
+                        if self.example_type == "single_tel":
                             passing_examples.append((row["run_number"], row["event_number"], tel_id))
-                            self.num_passing_images += 1
-                            self.num_passing_images_by_class_name[class_name] += 1
+                        self.num_passing_images += 1
+                        self.num_passing_images_by_class_name[class_name] += 1
+                        
                 # if example type is array, ???
-                elif self.example_type == "array":                               
+                if self.example_type == "array":                               
                     passing_examples.append((row["run_number"], row["event_number"]))
                     
 

--- a/scripts/print_dataset_metadata.py
+++ b/scripts/print_dataset_metadata.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
 
     for tel_type in metadata['total_telescopes'].keys():
         print("\n" + tel_type + ":\n", file=out)
-        num_images_before_cuts_by_class_name = metadata['num_images_before_cuts_by_class_name'][tel_type]
+        num_images_before_cuts_by_class_name = metadata['num_images_before_cuts_by_tel_and_class_name'][tel_type]
         total_num_images = sum(num_images_before_cuts_by_class_name.values())
         print("{} total images.".format(total_num_images), file=out)
         print("Num images by particle_id:", file=out)

--- a/scripts/print_run_metadata.py
+++ b/scripts/print_run_metadata.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Sun Oct 14 13:24:37 2018
+
+@author: jsevillamol
+"""
+
+import argparse
+import sys
+import yaml
+
+from ctlearn.data_loading import HDF5DataLoader
+from ctlearn.image_mapping import ImageMapper
+from ctlearn.data_processing import DataProcessor
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description=("Print train metadata for a .yaml run configuration")
+        )
+    parser.add_argument(
+        'config_file',
+        help=".yaml file with the run configuration"
+        )
+    parser.add_argument(
+        '--out_file',
+        help="Optional output file to write results to."
+        )
+    
+    args = parser.parse_args()
+    
+    with open(args.config_file, 'r') as config_file:
+        config = yaml.load(config_file)
+    
+
+    # Load options related to the data format and location
+    data_format = config['Data']['format']
+    data_files = []
+    with open(config['Data']['file_list']) as f:
+        for line in f:
+            line = line.strip()
+            if line and line[0] != "#":
+                data_files.append(line)
+	
+    data_loading_settings = config['Data'].get('Loading', {})
+
+    # Load options related to data processing
+    apply_processing = config['Data'].get('apply_processing', True)
+    data_processing_settings = config['Data'].get('Processing', {})
+    
+    # Load options related to image mapping
+    image_mapping_settings = config.get('Image Mapping', {})
+    if 'use_peak_times' in config['Data']['Loading']:
+        image_mapping_settings['use_peak_times'] = config['Data']['Loading']['use_peak_times']
+    else:
+        image_mapping_settings['use_peak_times'] = False
+
+    # Load options related to data loading
+    data_loader_mode = "train"
+    
+    # Create data processor
+    if apply_processing:
+        data_processor = DataProcessor(
+                image_mapper=ImageMapper(**image_mapping_settings),
+                **data_processing_settings)
+    else: data_processor = None
+
+    # Define data loading functions
+    if data_format == 'HDF5':
+        data_loader = HDF5DataLoader(
+                data_files,
+                mode=data_loader_mode,
+                data_processor=data_processor,
+                image_mapper=ImageMapper(**image_mapping_settings),
+                **data_loading_settings)
+
+    metadata = data_loader.get_metadata()
+
+    out = open(args.out_file,"w") if args.out_file else sys.stdout
+    
+    print("Tel {} ({} mode)\n".format(config['Data']['Loading']['selected_tel_type'], config['Data']['Loading']['example_type']), file=out)
+    
+    for i in metadata:
+        print("{}: {}\n".format(i,metadata[i]), file=out)
+
+    num_events_after_cuts_by_class_name = metadata['num_events_after_cuts_by_class_name']
+    total_num_events = sum(num_events_after_cuts_by_class_name.values())
+    print("\n{} total events.".format(total_num_events), file=out)
+    print("Num events by particle_id:", file=out)
+    for class_name in num_events_after_cuts_by_class_name:
+        print("{}: {} ({}%)".format( 
+                class_name, 
+                num_events_after_cuts_by_class_name[class_name], 
+                100 * float(num_events_after_cuts_by_class_name[class_name])/total_num_events),
+                file=out
+                )
+
+    num_images_after_cuts_by_class_name = metadata['num_images_after_cuts_by_class_name']
+    total_num_images = sum(num_images_after_cuts_by_class_name.values())
+    print("\n{} total images.".format(total_num_images), file=out)
+    print("Num images by particle_id:", file=out)
+    for class_name in num_images_after_cuts_by_class_name:
+        print("{}: {} ({}%)".format( 
+                class_name, 
+                num_images_after_cuts_by_class_name[class_name], 
+                100 * float(num_images_after_cuts_by_class_name[class_name])/total_num_images),
+                file=out
+                )
+            
+    num_val_examples_by_class_name = metadata['num_val_examples_by_class_name']
+    total_num_events = sum(num_val_examples_by_class_name.values())
+    print("\n{} total val examples.".format(total_num_events), file=out)
+    print("Num val examples by particle_id:", file=out)
+    for class_name in num_val_examples_by_class_name:
+        print("{}: {} ({}%)".format( 
+                class_name, 
+                num_val_examples_by_class_name[class_name], 
+                100 * float(num_val_examples_by_class_name[class_name])/total_num_events),
+                file=out
+                )
+    

--- a/scripts/print_run_metadata.py
+++ b/scripts/print_run_metadata.py
@@ -119,4 +119,5 @@ if __name__ == "__main__":
                 100 * float(num_val_examples_by_class_name[class_name])/total_num_events),
                 file=out
                 )
-    
+
+


### PR DESCRIPTION
This makes it so the after cuts image metadata is correctly counted when using array mode, introduces a new metadata field containing the validation set break up and creates a utility script to display the metadata after cuts and the validation metadata