### PR TITLE
Load data from multiple telescope types simultaneously

### DIFF
--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -140,7 +140,7 @@ Data:
         #   - 'size': Order by largest to smallest total sum of pixel values
         #   - null: Keep DataLoader ordering (by telescope ID)
         # How to sort telescope images when loading data in array mode.
-        sort_images_by: null
+        sorting: null
    
     # Settings for the TensorFlow Estimator input function.
     Input:

--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -46,7 +46,7 @@ Data:
         #   - 'SSTC': SST-2M GCT Telescope with CHEC Camera
         #   - 'VTS': VERITAS Telescope and Camera
         # List of telescope types to load.
-        selected_telescopes: ['LST']
+        selected_tel_types: ['LST']
         
         # Optional dictionary with string keys and list of integer values,
         # or null. If null, default is an empty dictionary.

--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -35,8 +35,8 @@ Data:
 		# If True, an additional channel is loaded indicated peak pulse arrival time per pixel
 		use_peak_times: False
 
-        # Optional string. Default: 'LST'
-        # Valid options:
+        # Optional list of tel_type strings or null. Default if null: ['LST']
+        # Valid tel_types:
         #   - 'LST': LST Telescope and Camera
         #   - 'MSTF': MST Telescope with FlashCAM Camera
         #   - 'MSTN': MST Telescope with NectarCAM Camera
@@ -45,13 +45,16 @@ Data:
         #   - 'SSTA': SST-2M ASTRI Telescope and Camera
         #   - 'SSTC': SST-2M GCT Telescope with CHEC Camera
         #   - 'VTS': VERITAS Telescope and Camera
-        # Telescope type to load.
-        selected_tel_type: 'LST'
+        # List of telescope types to load.
+        selected_telescopes: ['LST']
         
-        # Optional list of integers. Default: load all telescopes of the
-        # selected tel type.
-        # ID numbers of telescopes to load of the selected tel type.
-        selected_tel_ids: [1, 2, 3, 4]
+        # Optional dictionary with string keys and list of integer values,
+        # or null. If null, default is an empty dictionary.
+        # Valid keys are the tel_types listed above, and the values should be
+        # the tel_ids of the telescopes to load of that tel_type.
+        # Default if tel_type not in dict: load all telescopes of the tel_type.
+        selected_tel_ids:
+            LST: [1, 2, 3, 4]
 
         # Optional integer. Default: 1
         # Minimum number of triggered telescopes of the selected type which

--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -55,6 +55,13 @@ Data:
         # Default if tel_type not in dict: load all telescopes of the tel_type.
         selected_tel_ids:
             LST: [1, 2, 3, 4]
+        
+        # Optional Boolean. Default: False
+        # In array mode, merge the data arrays (images, triggers, and
+        # auxiliary info) for each telescope type into three combined data
+        # arrays, instead of returning them as sublists grouped by tel type.
+        # Images must have the same dimensions (at least post-processing)!
+        merge_tel_types: False
 
         # Optional integer. Default: 1
         # Minimum number of triggered telescopes of the selected type which

--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -61,11 +61,12 @@ Data:
         # auxiliary info) for each telescope type into three combined data
         # arrays, instead of returning them as sublists grouped by tel type.
         # Images must have the same dimensions (at least post-processing)!
-        merge_tel_types: False
+        merge_tel_types: false
 
-        # Optional integer. Default: 1
-        # Minimum number of triggered telescopes of the selected type which
-        # must be present for an event to be loaded.
+        # Optional int. Default: 1
+        # Minimum number of triggered telescopes among all selected 
+        # telescopes (of all types) which must be present for an event to be
+        # loaded. Telescopes that aren't selected don't count.
         min_num_tels: 1
 
         # Optional string. Default: don't apply any cuts.

--- a/ctlearn/data_loading.py
+++ b/ctlearn/data_loading.py
@@ -511,7 +511,7 @@ class HDF5DataLoader(DataLoader):
         # Create image by indexing into the trace using the mapping table, then adding a
         # dimension to given shape (length,width,1)
         image = self._image_mapper.map_image(trace, tel_type)
-        image = np.array(image, dtype=np.float32)
+        image = image.astype(np.float32)
 
         return image
 

--- a/ctlearn/data_processing.py
+++ b/ctlearn/data_processing.py
@@ -45,7 +45,7 @@ class DataProcessor():
         SortParams = namedtuple('SortParams', ['reverse', 'key'])
         self.sorting_params = {
                 # List triggered telescopes first
-                'trigger': SortParams(reverse=True, key=itemgetter(1))
+                'trigger': SortParams(reverse=True, key=itemgetter(1)),
                 # List from largest to smallest sum of pixel charges
                 'size': SortParams(reverse=True, 
                     key=lambda x: np.sum(x[0]))

--- a/ctlearn/data_processing.py
+++ b/ctlearn/data_processing.py
@@ -167,24 +167,24 @@ class DataProcessor():
     # list of additional auxiliary parameters produced by
     # the processing.
     def _process_image(self, image, tel_type, dummy_image=False):
-        auxiliary_info = []
+        auxiliary_input = []
 
         if dummy_image: # No trigger - image is blank
             if self.crop:
                 # Add dummy centroid position to aux info
-                auxiliary_info.extend([0.0, 0.0])
-            return image, auxiliary_info
+                auxiliary_input.extend([0.0, 0.0])
+            return image, auxiliary_input
 
         if self.crop:
             image, *shower_position = self._crop_image(image, tel_type)
             image_width = self._image_mapper.image_shapes[tel_type][0]
             normalized_shower_position = [float(p) / image_width for p
                     in shower_position] 
-            auxiliary_info.extend(normalized_shower_position)
+            auxiliary_input.extend(normalized_shower_position)
         if self.normalization:
             image = self._normalize_image(image, tel_type)
 
-        return image, auxiliary_info
+        return image, auxiliary_input
 
     # Process the example using the specified processing options
     def process_example(self, data, label, tel_types, example_type='array'):
@@ -209,7 +209,8 @@ class DataProcessor():
                 tel_image, aux_input = self._process_image(tel_image, tel_type,
                         dummy_image=dummy_image)
                 data[type_i][0][tel_i] = tel_image
-                data[type_i][2][tel_i] = np.append(tel_aux_input, aux_input)
+                data[type_i][2][tel_i] = np.append(tel_aux_input,
+                        aux_input).astype(np.float32)
       
             # Sort the images, triggers, and grouped auxiliary inputs together
             if self.sorting is not None:

--- a/ctlearn/data_processing.py
+++ b/ctlearn/data_processing.py
@@ -1,6 +1,8 @@
-import numpy as np
-import cv2
+from collections import namedtuple
 from operator import itemgetter
+
+import cv2
+import numpy as np
 
 from ctlearn.image_mapping import ImageMapper
 
@@ -14,7 +16,7 @@ class DataProcessor():
             thresholds=None,
             return_cleaned_images=False,
             normalization=None,
-            sort_images_by=None
+            sorting=None
             ):
         
         self._image_mapper = image_mapper
@@ -40,10 +42,19 @@ class DataProcessor():
         else:
             raise ValueError("Invalid normalization method: {}. Select 'log' or None.".format(normalization))
 
-        if sort_images_by in ['trigger', 'size', None]:
-            self.sort_images_by = sort_images_by
+        SortParams = namedtuple('SortParams', ['reverse', 'key'])
+        self.sorting_params = {
+                # List triggered telescopes first
+                'trigger': SortParams(reverse=True, key=itemgetter(1))
+                # List from largest to smallest sum of pixel charges
+                'size': SortParams(reverse=True, 
+                    key=lambda x: np.sum(x[0]))
+                }
+        if sorting in list(self.sorting_params) + [None]:
+            self.sorting = sorting
         else:
-            raise ValueError("Invalid image sorting method: {}. Select 'trigger', 'size', or None.".format(sort_images_by))
+            raise ValueError("Invalid image sorting method: {}. Select "
+                    "'trigger', 'size', or None.".format(sorting))
 
         self.image_shapes = {}
         for tel_type in self._image_mapper.image_shapes:
@@ -155,68 +166,60 @@ class DataProcessor():
     # on a given image. Returns the processed image and a
     # list of additional auxiliary parameters produced by
     # the processing.
-    def _process_image(self, image, tel_type):
+    def _process_image(self, image, tel_type, dummy_image=False):
         auxiliary_info = []
+
+        if dummy_image: # No trigger - image is blank
+            if self.crop:
+                # Add dummy centroid position to aux info
+                auxiliary_info.extend([0.0, 0.0])
+            return image, auxiliary_info
+
         if self.crop:
             image, *shower_position = self._crop_image(image, tel_type)
-            normalized_shower_position = [float(i)/self._image_mapper.image_shapes[tel_type][0] for i in shower_position] 
+            image_width = self._image_mapper.image_shapes[tel_type][0]
+            normalized_shower_position = [float(p) / image_width for p
+                    in shower_position] 
             auxiliary_info.extend(normalized_shower_position)
         if self.normalization:
             image = self._normalize_image(image, tel_type)
 
         return image, auxiliary_info
 
-    def process_example(self, data, label, tel_types):
+    # Process the example using the specified processing options
+    def process_example(self, data, label, tel_types, example_type='array'):
         
-        # infer whether example is single tel or array based on
-        # number of elements in data
-        if len(data) == 1:
-            example_type = "single_tel"
-        else:
-            example_type = "array"
-
-        if example_type == "single_tel":
+        if example_type not in ['single_tel', 'array']:
+            raise ValueError("Invalid example type selection: {}. Select "
+                    "'single_tel' or 'array'.".format(example_type))
+        
+        # For single tel, just need to process the image
+        if example_type == 'single_tel':
             image = data[0]
-
             image, _ = self._process_image(image, tel_types[0])
             data = [image]
-            
-            return [data, label]
-        
-        elif example_type == "array":
-            images = data[0]
-            triggers = data[1]
-            aux_inputs = data[2]
+            return data, label
 
-            for tel_images, tel_type in zip(images, tel_types):
-                image_shape = self.image_shapes[tel_type]
-                for i, image in enumerate(tel_images):
-                    trigger = triggers[i]
-                    if trigger == 0:
-                        # telescope did not trigger, so provide a
-                        # zeroed-out image
-                        images[i] = np.zeros(image_shape)
-                        if self.crop:
-                            # add dummy centroid position to aux info
-                            aux_inputs[i].extend([0.0, 0.0])
-                    else:
-                        image, auxiliary_info = self._process_image(images[i], tel_type)
-                        images[i] = image
-                        aux_inputs[i].extend(auxiliary_info)
+        # Otherwise, array example. More complex processing is needed.
+        for type_i, tel_type in enumerate(tel_types):
+            for tel_i, tel_trigger in enumerate(data[type_i][1]):
+                tel_image = data[type_i][0][tel_i]
+                tel_aux_input = data[type_i][2][tel_i]
+                dummy_image = True if tel_trigger == 0 else False
+                tel_image, aux_input = self._process_image(tel_image, tel_type,
+                        dummy_image=dummy_image)
+                data[type_i][0][tel_i] = tel_image
+                data[type_i][2][tel_i] = np.append(tel_aux_input, aux_input)
       
-            if self.sort_images_by == "trigger":
-                # Sort the images, triggers, and grouped auxiliary inputs by
-                # trigger, listing the triggered telescopes first
-                images, triggers, aux_inputs = map(list,
-                        zip(*sorted(zip(images, triggers, aux_inputs), reverse=True, key=itemgetter(1))))
-            elif self.sort_images_by == "size":
-                # Sort images by size (sum of charge in all pixels) from largest to smallest
-                images, triggers, aux_inputs = map(list,
-                        zip(*sorted(zip(images, triggers, aux_inputs), reverse=True, key=lambda x: np.sum(x[0]))))
-            
-            data = [images, triggers, aux_inputs]
-
-            return [data, label]
+            # Sort the images, triggers, and grouped auxiliary inputs together
+            if self.sorting is not None:
+                # Sort according to the specified parameters
+                sort_params = self.sorting_params[self.sorting]
+                data[type_i] = list(map(list, zip(*sorted(zip(*data[type_i]),
+                        key=sort_params.key,
+                        reverse=sort_params.reverse))))
+        
+        return data, label
 
     def get_metadata(self):
         


### PR DESCRIPTION
Closes #54 and closes #57. HDF5DataLoader can now load data from multiple telescope types at once, and return them either as separate data arrays for each telescope type or as stacked data arrays including telescopes of all types (which presupposes they have the same post-processing shape). The provided models haven't been changed, so they should be run with the Data:Loading settings `selected_tel_types=[<tel_type>]` and `merge_telescope_types=true`.