### PR TITLE
Fix bug with telescope indices

### DIFF
--- a/ctlearn/data_loading.py
+++ b/ctlearn/data_loading.py
@@ -683,7 +683,7 @@ class HDF5DataLoader(DataLoader):
                     num_triggered_tels += num_tels
                     num_triggered_tels_by_type[tel_type] = num_tels
                     triggered_tel_ids.extend([tel_id for tel_id in tel_ids
-                        if tel_id_to_index[tel_id] in triggered_image_indices])
+                        if image_indices[tel_id_to_index[tel_id]] != 0])
                 if num_triggered_tels < self.min_num_tels:
                     continue
 


### PR DESCRIPTION
When appending ted ids to the list of triggered telescopes, the index used was mistakenly the telescope number index (e.g. 0-3 for LSTs), not the image index in the file, causing the incorrect telescopes to be read.

Closes #84.

I tested this fix with a single tel LST training run using the config settings listed in #84 and got validation accuracy 69.50% and AUC 0.7767, very close to the v0.2.0 benchmarks.