### PR TITLE
TensorFlow and OpenCV upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Next, download and install [Anaconda](https://www.anaconda.com/download/), or, f
 conda env create -f </installation/path>/ctlearn/environment-<MODE>.yml
 ```
 
-where `<MODE>` is either 'cpu' or 'gpu', denoting the TensorFlow version to be installed. If installing the GPU version of TensorFlow, verify that your system fulfills all the requirements [here](https://www.tensorflow.org/install/install_linux#NVIDIARequirements).
+where `<MODE>` is either 'cpu', 'gpu' (for linux systems) or 'macos' (for macOS systems), denoting the TensorFlow version to be installed. If installing the GPU version of TensorFlow, verify that your system fulfills all the requirements [here](https://www.tensorflow.org/install/install_linux#NVIDIARequirements). Note that there is no GPU-enabled TensorFlow version for macOS yet.
 
 Finally, install CTLearn into the new conda environment with pip:
 
@@ -39,7 +39,7 @@ NOTE for developers: If you wish to fork/clone the respository and make changes 
 ### Dependencies
 
 - Python 3.6.5
-- TensorFlow 1.9.0
+- TensorFlow 1.12.0
 - NumPy
 - AstroPy
 - OpenCV

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -1,5 +1,5 @@
 # conda env create -f environment-cpu.yml
-name: ctlearn-cpu
+name: ctlearn
 channels:
     - conda-forge
     - menpo

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -1,5 +1,5 @@
 # conda env create -f environment-gpu.yml
-name: ctlearn-gpu
+name: ctlearn
 channels:
     - conda-forge
     - menpo

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -1,5 +1,5 @@
-# conda env create -f requirements-gpu.yml
-name: ctlearn
+# conda env create -f environment-gpu.yml
+name: ctlearn-gpu
 channels:
     - conda-forge
     - menpo
@@ -8,12 +8,12 @@ dependencies:
     - matplotlib
     - numpy
     - astropy
-    - opencv3
+    - opencv
     - pillow
     - pip
-    # TensorFlow-GPU v1.9.0:
+    # TensorFlow-GPU v1.12.0:
     - pip:
-        - https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.9.0-cp36-cp36m-linux_x86_64.whl
+        - https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.12.0-cp36-cp36m-linux_x86_64.whl
     - pytables
     - pyyaml
     - scikit-learn

--- a/environment-macos.yml
+++ b/environment-macos.yml
@@ -1,5 +1,5 @@
-# conda env create -f environment-cpu.yml
-name: ctlearn-cpu
+# conda env create -f environment-macos.yml
+name: ctlearn
 channels:
     - conda-forge
     - menpo
@@ -13,7 +13,7 @@ dependencies:
     - pip
     # TensorFlow-CPU v1.12.0:
     - pip:
-        - https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0-cp36-cp36m-linux_x86_64.whl
+        - https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.12.0-py3-none-any.whl
     - pytables
     - pyyaml
     - scikit-learn


### PR DESCRIPTION
This PR upgrades the version of TensorFlow to 1.12 and changes the opencv package from 'opencv3' to 'opencv' so CTLearn can be installed on machines running macOS. No significant changes in benchmark performances after the upgrades (as expected). 