### PR TITLE
Upgrade to Python 3.7 and TensorFlow 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ NOTE for developers: If you wish to fork/clone the respository and make changes 
 
 ### Dependencies
 
-- Python 3.6.5
-- TensorFlow 1.12.0
+- Python 3.7.3
+- TensorFlow 1.13.1
 - NumPy
 - AstroPy
 - OpenCV

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -4,16 +4,16 @@ channels:
     - conda-forge
     - menpo
 dependencies:
-    - python=3.6.5
+    - python=3.7.3
     - matplotlib
     - numpy
     - astropy
     - opencv
     - pillow
     - pip
-    # TensorFlow-CPU v1.12.0:
+    # TensorFlow-CPU v1.13.1:
     - pip:
-        - https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0-cp36-cp36m-linux_x86_64.whl
+        - https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.13.1-cp37-cp37m-linux_x86_64.whl
     - pytables
     - pyyaml
     - scikit-learn

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -4,16 +4,16 @@ channels:
     - conda-forge
     - menpo
 dependencies:
-    - python=3.6.5
+    - python=3.7.3
     - matplotlib
     - numpy
     - astropy
     - opencv
     - pillow
     - pip
-    # TensorFlow-GPU v1.12.0:
+    # TensorFlow-GPU v1.13.1:
     - pip:
-        - https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.12.0-cp36-cp36m-linux_x86_64.whl
+        - https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.13.1-cp37-cp37m-linux_x86_64.whl
     - pytables
     - pyyaml
     - scikit-learn

--- a/environment-macos.yml
+++ b/environment-macos.yml
@@ -4,16 +4,16 @@ channels:
     - conda-forge
     - menpo
 dependencies:
-    - python=3.6.5
+    - python=3.7.3
     - matplotlib
     - numpy
     - astropy
     - opencv
     - pillow
     - pip
-    # TensorFlow-CPU v1.12.0:
+    # TensorFlow-CPU v1.13.1:
     - pip:
-        - https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.12.0-py3-none-any.whl
+        - https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-1.13.1-py3-none-any.whl
     - pytables
     - pyyaml
     - scikit-learn


### PR DESCRIPTION
Python -> 3.7.3
TensorFlow -> 1.13.1

Python 3.7 is needed for compatibility with DL1DataHandler. CUDA 10 is required for this upgrade for TensorFlow-GPU.

I ran the following benchmarks using the v0.3.0 benchmarks config file to validate the performance with the new dependency versions and obtained the following results:

Telescope Type | Validation Accuracy | Validation AUC | Training Time
---|---|---|---
LST:LSTCam Single Tel | 70.06% | 0.7896 | 0h 24m 24s
LST:LSTCam Array | 72.86% | 0.8283 | 0h 33m 18s
MST:FlashCam Single Tel | 75.23% | 0.8377 | 0h 33m 5s
MST:FlashCam Array | 80.42% | 0.8963 | 1h 55m 36s
SCT:SCTCam Single Tel | 78.02% | 0.8698 | 0h 41m 45s
SCT:SCTCam Array | 82.12% | 0.9101 | 2h 8m 27s
SST:CHEC Single Tel | 74.96% | 0.8295 | 31m 27s
SST:CHEC Array | 82.13% | 0.9087 | 1h 50m 3s

Compared to the [v0.2.0 benchmarks](https://github.com/ctlearn-project/ctlearn/blob/master/config/v_0_2_0_benchmarks/README.md) (for which metrics are available), the accuracy change for all telescopes tested was <1% except for CHEC, which increased by 1.06% for single tel and 1.49% for array. The AUC change was <0.01 for all telescopes except CHEC single tel which increased by 0.0177.

Compared to those benchmarks, training time decreased by an average of ~34% for single tel runs and ~10% for array runs, conducted on the same hardware.