### PR TITLE
Improve training performance

### DIFF
--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -402,8 +402,7 @@ Training:
     # Randomly chosen fraction of data to set aside for validation.
     validation_split: 0.1
 
-    # Required int.
-    # Number of steps (usually, batches) on which to train.
+    # Required number of epochs on which to train.
     max_steps: 10000
 
     # Required string.

--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -402,14 +402,9 @@ Training:
     # Randomly chosen fraction of data to set aside for validation.
     validation_split: 0.1
 
-    # Required integer.
-    # Number of validations made before finishing training. If 0, run forever.
-    num_validations: 0
-
-    # Required integer.
-    # Number of training steps to run before each evaluation
-    # on the validation set.
-    num_training_steps_per_validation: 1000
+    # Required int.
+    # Number of steps (usually, batches) on which to train.
+    max_steps: 10000
 
     # Required string.
     # Valid options: ['Adadelta', 'Adam', 'RMSProp', 'SGD']

--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -228,17 +228,9 @@ Input:
     # Optional integer. Default: 1
     batch_size: 32
 
-    # Number of examples to load into memory before shuffling.
-    # For valid results, either randomize the example order
-    # in the generator (i.e. set Data:shuffle = True) or set to
-    # greater than or equal to the number of examples in the dataset.
-    # For best performance, set to less than the total number of examples.
-    # Optional integer. Default: All examples in dataset
-    shuffle_buffer_size: 10000
-
     # Maximum number of batches to be buffered when prefetching.
     # Optional integer. Default: 1
-    prefetch_buffer_size: 8
+    prefetch_buffer_size: 1
 
 # Settings for the TensorFlow model. The options in this and the
 # Model Parameters section are passed to the Estimator model_fn

--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -228,9 +228,15 @@ Input:
     # Optional integer. Default: 1
     batch_size: 32
 
-    # Maximum number of batches to be buffered when prefetching.
-    # Optional integer. Default: 1
-    prefetch_buffer_size: 1
+    # Arguments to tf.data.experimental.prefetch_to_device
+    # to prefetch examples to a specified device.
+    # Optional dictionary or null. Default if null: do not prefetch
+    prefetch_to_device:
+        # Device to which to prefetch (string)
+        device: "/gpu:0"
+        # Number of elements to prefetch
+        # Optional; will be automatically optimized if missing or null
+        buffer_size: null
 
 # Settings for the TensorFlow model. The options in this and the
 # Model Parameters section are passed to the Estimator model_fn

--- a/config/example_config.yml
+++ b/config/example_config.yml
@@ -403,7 +403,7 @@ Training:
     validation_split: 0.1
 
     # Required number of epochs on which to train.
-    max_steps: 10000
+    num_epochs: 20
 
     # Required string.
     # Valid options: ['Adadelta', 'Adam', 'RMSProp', 'SGD']

--- a/ctlearn/run_model.py
+++ b/ctlearn/run_model.py
@@ -229,10 +229,10 @@ def run_model(config, mode="train", debug=False, log_to_file=False):
         num_training_examples = math.floor((1 - validation_split) * len(reader))
         training_indices = indices[:num_training_examples]
         validation_indices = indices[num_training_examples:]
+        logger.info("Number of epochs: {}".format(
+            config['Training']['num_epochs']))
         logger.info("Number of training steps per epoch: {}".format(
             int(num_training_examples / batch_size)))
-        logger.info("Max number of training steps: {}".format(
-            config['Training']['max_steps']))
 
     if mode == 'load_only':
 
@@ -439,7 +439,8 @@ def run_model(config, mode="train", debug=False, log_to_file=False):
 
         # Train and evaluate the model
         logger.info("Training and evaluating...")
-        max_steps = config['Training']['max_steps']
+        max_steps = int(config['Training']['num_epochs']
+                        * num_training_examples / batch_size)
         train_input_fn = lambda: input_fn(reader, training_indices,
                                           shuffle_and_repeat=True,
                                           **config['Input'])

--- a/ctlearn/run_model.py
+++ b/ctlearn/run_model.py
@@ -262,12 +262,11 @@ def run_model(config, mode="train", debug=False, log_to_file=False):
             dataset = dataset.shuffle(buffer_size=len(indices), seed=seed,
                                       reshuffle_each_iteration=True)
             dataset = dataset.repeat()
-        # Do not use the num_parallel_calls option -
-        # it causes itermittent segmentation faults with the HDF5 files
-        # and may not provide a speedup with tf.py_function anyway.
         dataset = dataset.map(lambda x: tf.py_function(func=reader.__getitem__,
                                                        inp=[x],
-                                                       Tout=output_dtypes))
+                                                       Tout=output_dtypes),
+                              num_parallel_calls=tf.data.experimental.AUTOTUNE)
+
         dataset = dataset.batch(batch_size)
         if prefetch_to_device is not None:
             dataset = dataset.apply(


### PR DESCRIPTION
This PR makes training models with CTLearn faster and more correct.

First, the input function has been restructured to use `Dataset.from_tensor_slices()` and `Dataset.map()` for simplicity and performance. With https://github.com/cta-observatory/dl1-data-handler/pull/88, using the `num_parallel_calls` argument of `Dataset.map()` works, enabling a ~40% speedup on my machine. In addition, `tf.data.experimental.prefetch_to_device()` is used to prefetch examples directly to GPU, providing another 20-25% speedup.

Second, the training and validation loop has been restructured to properly shuffle and use all of the data. Previously, only a small buffer of examples was shuffled and trained on during each iteration. In particular, when a random seed was set, the shuffling would be deterministic on each iteration, so the same set of examples would be used each time. As a result, only a small subset of the training set was actually used for training!

This PR fixes this problem by using `tf.estimator.train_and_evaluate()` to construct the training input function only once, combined with `Dataset.repeat()` to allow training for an indefinite number of epochs. Because of the previous changes to the input function, only the example identifiers are shuffled, allowing for a perfect shuffle for virtually any sized dataset. To support this API, the max_steps argument is used to determine the total number of steps to train, as opposed to the number of validations and steps between validations.

Finally, the now-obsolete configuration parameters `shuffle_buffer_size`, `prefetch_buffer_size`, `num_validations`, and `num_training_steps_per_validation` have been removed, and new parameters `prefetch_to_device` and `max_steps` have been added to support the new features.