### PR TITLE
Major upgrade to TF2 (v2.7)

### DIFF
--- a/config/v_0_6_0_benchmarks/LSTCam_TRN_lowcut.yml
+++ b/config/v_0_6_0_benchmarks/LSTCam_TRN_lowcut.yml
@@ -1,0 +1,113 @@
+#Logging:
+#    model_directory: '/data3/users/tjark/logs/testing_callback_energy/'
+Data_format: 'stage1'
+#Reco: ['particletype' , 'energy', 'direction']
+Data:
+    # Allow to overwrite config setting based on tasks selection
+    allow_overwrite: true
+    file_list: '/home/ir-mien1/rds/rds-iris-ip007/ir-mien1/file_lists/Prod5_balanced_train.txt'
+    #file_list: '/home/tjark/tf2update_covid/test.txt'
+    example_identifiers_file: '/home/ir-mien1/example_identifiers/LSTCam_mono_balanced.h5'
+    mode: 'mono'
+    selected_telescope_types: ['LST_LST_LSTCam']
+    #selected_telescope_ids: {'LST_LST_LSTCam': [1,2,3,4]}
+    # For testing select LST1 only
+    #selected_telescope_ids: {'LST_LST_LSTCam': [1]}
+    shuffle: true
+    seed: 1234
+    image_channels: ['image', 'peak_time']
+    mapping_settings:
+        camera_types: ['LSTCam']
+        mapping_method:
+            'LSTCam': 'bilinear_interpolation'
+        padding:
+            'LSTCam': 2
+        mask_interpolation: false
+    event_selection: 
+        - {col_name: "hillas_intensity", min_value: 50.0}
+        - {col_name: "leakage_intensity_width_2", max_value: 0.2}
+Input:
+    shuffle: true
+    batch_size_per_worker: 64
+    concat_telescopes: false
+Model:
+    #sudo apt install graphviz
+    plot_model: false
+    model_directory: '/home/ir-mien1/tf2/ctlearn/ctlearn/default_models/'
+    backbone: {module: 'res_net', function: 'res_net_model'}
+    head: {module: 'head', function: 'standard_head'}
+Model Parameters:
+    attention: {mechanism: 'Squeeze-and-Excitation', ratio: 16}
+    res_net:
+        network: {module: 'resnet_engine', function: 'stacked_res_blocks'}
+        #init_layer: {filters: 64, kernel_size: 7, strides: 1}
+        #init_max_pool: {size: 3, strides: 2}
+        pretrained_weights: null
+    single_cnn:
+        network: {module: 'basic', function: 'conv_block'}
+        pretrained_weights: null
+    cnn_rnn:
+        cnn_block: {module: 'basic', function: 'conv_block'}
+        pretrained_weights: null
+        dropout_rate: 0.5
+    variable_input_model:
+        cnn_block: {module: 'basic', function: 'conv_block'}
+        telescope_combination: 'feature_maps'
+        network_head: {module: 'basic', function: 'conv_head'}
+        pretrained_weights: null
+    basic:
+        conv_block:
+            layers:
+                - {filters: 32, kernel_size: 3}
+                - {filters: 32, kernel_size: 3}
+                - {filters: 64, kernel_size: 3}
+                - {filters: 128, kernel_size: 3}
+            max_pool: {size: 2, strides: 2}
+            bottleneck: null
+            batchnorm: false
+        fully_connect:
+            layers: [1024, 512, 256, 128, 64]
+            batchnorm: false
+        conv_head:
+            layers:
+                - {filters: 64, kernel_size: 3}
+                - {filters: 128, kernel_size: 3}
+                - {filters: 256, kernel_size: 3}
+            final_avg_pool: true
+            batchnorm: false
+        batchnorm_decay: 0.99
+    resnet_engine:
+        name: 'ThinResNet'
+        stacked_res_blocks:
+            residual_block: 'bottleneck'
+            architecture:
+                - {filters: 48, blocks: 2}
+                - {filters: 96, blocks: 3}
+                - {filters: 128, blocks: 3}
+                - {filters: 256, blocks: 3}
+    standard_head:
+        particletype: {class_names: ['proton', 'gamma'], fc_head: [512, 256, 2], weight: 1.0}
+        energy: {fc_head: [512, 256, 1], weight: 1.0}
+        direction: {fc_head: [512, 256, 2], weight: 1.0}
+Training:
+    validation_split: 0.05
+    num_epochs: 5
+    verbose: 2
+    workers: 1
+    optimizer: 'Adam'
+    adam_epsilon: 1.0e-8
+    base_learning_rate: 0.0001
+    #callbacks:
+    #    - {EarlyStopping: {monitor: 'loss', patience: 3, restore_best_weights: True}}
+    #scale_learning_rate: false
+    #variables_to_train: null
+#Prediction:
+#    file: 'LST1_TRN_lowcut'
+#    prediction_file_lists:
+#        'proton': '/home/ir-mien1/rds/rds-iris-ip007/ir-mien1/file_lists/Prod5_proton_test.txt'
+#        'diffuse': '/home/ir-mien1/rds/rds-iris-ip007/ir-mien1/file_lists/Prod5_gamma-diffuse_test.txt'
+#        'gamma': '/home/ir-mien1/rds/rds-iris-ip007/ir-mien1/file_lists/Prod5_gamma_test.txt'
+#        'electron': '/home/ir-mien1/rds/rds-iris-ip007/ir-mien1/file_lists/Prod5_electron_test.txt'
+#    save_labels: false
+#    save_identifiers: false
+

--- a/ctlearn/data_loader.py
+++ b/ctlearn/data_loader.py
@@ -1,152 +1,119 @@
-import importlib
-import logging
-import os
-import pkg_resources
-import sys
-import time
-
 import numpy as np
-import pandas as pd
 import tensorflow as tf
-import yaml
 
 
-def setup_DL1DataReader(config, mode):
-    # Parse file list or prediction file list
-    if mode in ['train', 'load_only']:
-        if isinstance(config['Data']['file_list'], str):
-            data_files = []
-            with open(config['Data']['file_list']) as f:
-                for line in f:
-                    line = line.strip()
-                    if line and line[0] != "#":
-                        data_files.append(line)
-            config['Data']['file_list'] = data_files
-        if not isinstance(config['Data']['file_list'], list):
-            raise ValueError("Invalid file list '{}'. "
-                             "Must be list or path to file".format(config['Data']['file_list']))
-    else:
-        file_list = config['Prediction']['prediction_file_lists'][config['Prediction']['prediction_label']]
-        if file_list.endswith(".txt"):
-            data_files = []
-            with open(file_list) as f:
-                for line in f:
-                    line = line.strip()
-                    if line and line[0] != "#":
-                        data_files.append(line)
-            config['Data']['file_list'] = data_files
-        elif file_list.endswith(".h5"):
-            config['Data']['file_list'] = [file_list]
-        if not isinstance(config['Data']['file_list'], list):
-            raise ValueError("Invalid prediction file list '{}'. "
-                             "Must be list or path to file".format(file_list))
+class KerasBatchGenerator(tf.keras.utils.Sequence):
+    'Generates batches for Keras application'
+    def __init__(self, DL1DataReaderDL1DH, indices, batch_size=64, shuffle=True):
+        'Initialization'
+        self.DL1DataReaderDL1DH = DL1DataReaderDL1DH
+        self.batch_size = batch_size
+        self.indices = indices
+        self.shuffle = shuffle
+        self.on_epoch_end()
+        
+        # Decrypt the example description
+        # Features
+        self.trg_pos, self.trg_shape  = None, None
+        self.img_pos, self.img_shape  = None, None
+        self.prm_pos, self.prm_shape  = None, None
+        # Labels
+        self.prt_pos = None
+        self.enr_pos = None
+        self.drc_pos = None
 
-    data_format = config.get('Data_format', 'stage1')
-    if data_format == 'dl1dh':
-        # Parse list of event selection filters
-        event_selection = {}
-        for s in config['Data'].get('event_selection', {}):
-            s = {'module': 'dl1_data_handler.filters', **s}
-            filter_fn, filter_params = load_from_module(**s)
-            event_selection[filter_fn] = filter_params
-        config['Data']['event_selection'] = event_selection
-
-        # Parse list of image selection filters
-        image_selection = {}
-        for s in config['Data'].get('image_selection', {}):
-            s = {'module': 'dl1_data_handler.filters', **s}
-            filter_fn, filter_params = load_from_module(**s)
-            image_selection[filter_fn] = filter_params
-        config['Data']['image_selection'] = image_selection
-
-    # Parse list of Transforms
-    transforms = []
-    for t in config['Data'].get('transforms', {}):
-        t = {'module': 'dl1_data_handler.transforms', **t}
-        transform, args = load_from_module(**t)
-        transforms.append(transform(**args))
-    config['Data']['transforms'] = transforms
-
-    # Convert interpolation image shapes from lists to tuples, if present
-    if 'interpolation_image_shape' in config['Data'].get('mapping_settings',{}):
-        config['Data']['mapping_settings']['interpolation_image_shape'] = {
-            k: tuple(l) for k, l in config['Data']['mapping_settings']['interpolation_image_shape'].items()}
+        for i, desc in enumerate(self.DL1DataReaderDL1DH.example_description):
+            if 'trigger' in desc['name']:
+                self.trg_pos = i
+                self.trg_shape = desc['shape']
+            elif 'image' in desc['name']:
+                self.img_pos = i
+                #print(desc['shape'])
+                #print(int(desc['shape']))
+                self.img_shape = desc['shape']
+            elif 'parameters' in desc['name']:
+                self.prm_pos = i
+                self.prm_shape = desc['shape']
+            elif 'particletype' in desc['name']:
+                self.prt_pos = i
+            elif 'energy' in desc['name']:
+                self.enr_pos = i
+            elif 'direction' in desc['name']:
+                self.drc_pos = i
+        
+        #ToDo: Reshape inputs into proper dimensions for telescopes concatanate for MAGIC
+        concat_telescopes = False
+        #config['Input'].get('concat_telescopes', False)
+        if concat_telescopes:
+            self.img_shape = (self.img_shape[1], self.img_shape[2], self.img_shape[0]*self.img_shape[3])
 
 
-    # Possibly add additional info to load if predicting to write later
-    if mode == 'predict':
+    def __len__(self):
+        'Denotes the number of batches per epoch'
+        return int(np.floor(len(self.indices) / self.batch_size))
 
-        if 'Prediction' not in config:
-            config['Prediction'] = {}
+    def __getitem__(self, index):
+        'Generate one batch of data'
+        return self.__data_generation(self.indices[index*self.batch_size:(index+1)*self.batch_size])
 
-        if config['Prediction'].get('save_identifiers', False):
-            if 'event_info' not in config['Data']:
-                config['Data']['event_info'] = []
-            config['Data']['event_info'].extend(['event_id', 'obs_id'])
-            if config['Data']['mode'] == 'mono':
-                if 'array_info' not in config['Data']:
-                    config['Data']['array_info'] = []
-                config['Data']['array_info'].append('id')
+    def on_epoch_end(self):
+        'Updates indexes after each epoch'
+        if self.shuffle == True:
+            np.random.shuffle(self.indices)
 
-    return config['Data']
+    def __data_generation(self, batch_indices):
+        'Generates data containing batch_size samples'
+        # Initialization
+        if self.img_pos is not None:
+            images = np.empty((self.batch_size, *self.img_shape))
+        if self.prm_pos is not None:
+            parameters = np.empty((self.batch_size, *self.prm_shape))
+        
+        if self.prt_pos is not None:
+            particletype = np.empty((self.batch_size))
+        if self.enr_pos is not None:
+            energy = np.empty((self.batch_size))
+        if self.drc_pos is not None:
+            direction = np.empty((self.batch_size, 2))
 
-def load_from_module(name, module, path=None, args=None):
-    if path is not None and path not in sys.path:
-        sys.path.append(path)
-    mod = importlib.import_module(module)
-    fn = getattr(mod, name)
-    params = args if args is not None else {}
-    return fn, params
+        # Generate data
+        for i, index in enumerate(batch_indices):
+            event = self.DL1DataReaderDL1DH[index]
+            # Fill the features
+            if self.img_pos is not None:
+                images[i] = event[self.img_pos]
+                #images[ind] = np.reshape(event[self.img_pos], self.img_shape)
+            if self.prm_pos is not None:
+                parameters[i] = event[self.prm_pos]
+            # Fill the labels
+            if self.prt_pos is not None:
+                particletype[i] = event[self.prt_pos]
+            if self.enr_pos is not None:
+                energy[i] = event[self.enr_pos]
+            if self.drc_pos is not None:
+                direction[i] = event[self.drc_pos]
 
-# Define format for TensorFlow dataset
-def setup_TFdataset_format(config, example_description, labels):
-
-    config['Input']['output_names'] = [d['name'] for d
-                                       in example_description]
-    # TensorFlow does not support conversion for NumPy unsigned dtypes
-    # other than int8. Work around this by doing a manual conversion.
-    dtypes = [d['dtype'] for d in example_description]
-    for i, dtype in enumerate(dtypes):
-        for utype, stype in [(np.uint16, np.int32), (np.uint32, np.int64)]:
-            if dtype == utype:
-                dtypes[i] = stype
-    config['Input']['output_dtypes'] = tuple(tf.as_dtype(d) for d in dtypes)
-    config['Input']['label_names'] = config['Model']['tasks']
-
-    return config['Input']
-
-# Define input function for TF Estimator
-def input_fn(reader, indices, output_names, output_dtypes,
-             label_names, shuffle_and_repeat=False, num_epochs=None, seed=None,
-             batch_size=1, prefetch_to_device=None,
-             add_labels_to_features=False):
-
-    dataset = tf.data.Dataset.from_tensor_slices(indices)
-    if shuffle_and_repeat:
-        dataset = dataset.shuffle(buffer_size=len(indices), seed=seed,
-                                      reshuffle_each_iteration=True)
-        dataset = dataset.repeat(num_epochs)
-    dataset = dataset.map(lambda x: tf.py_function(func=reader.__getitem__,
-                                                   inp=[x],
-                                                   Tout=output_dtypes),
-                          num_parallel_calls=tf.data.experimental.AUTOTUNE)
-
-    dataset = dataset.batch(batch_size)
-    if prefetch_to_device is not None:
-        dataset = dataset.apply(
-            tf.data.experimental.prefetch_to_device(**prefetch_to_device))
-
-    iterator = dataset.make_one_shot_iterator()
-
-    # Return a batch of features and labels
-    example = iterator.get_next()
-
-    features, labels = {}, {}
-    for tensor, name in zip(example, output_names):
-         dic = labels if name in label_names else features
-         dic[name] = tensor
-
-    if add_labels_to_features:  # for predict mode
-         features['labels'] = labels
-
-    return features, labels
+        features = {}
+        if self.img_pos is not None:
+            features['images'] = images
+        if self.prm_pos is not None:
+            features['parameters'] = parameters
+            
+        labels = {}
+        if self.prt_pos is not None:
+            #ToDo: Take num_classes from config settings‚
+            labels['particletype'] = tf.keras.utils.to_categorical(particletype, num_classes=2)
+            label = tf.keras.utils.to_categorical(particletype, num_classes=2)
+        if self.enr_pos is not None:
+            labels['energy'] = energy
+            label = energy
+        if self.drc_pos is not None:
+            labels['direction'] = direction
+            label = direction
+    
+        # Temp fix till keras support class weights for multiple outputs or I wrote custom loss
+        # https://github.com/keras-team/keras/issues/11735
+        if len(labels) == 1:
+            labels = label
+            
+        return features, labels

--- a/ctlearn/default_models/head.py
+++ b/ctlearn/default_models/head.py
@@ -1,0 +1,56 @@
+
+import tensorflow as tf
+from ctlearn.default_models.basic import fully_connect
+
+def standard_head(inputs, tasks, params):
+
+    # Get the settings for the standard head
+    standard_head_settings = params['standard_head']
+    
+    logits ={}
+    losses = {}
+    loss_weights = {}
+    metrics = {}
+    if 'particletype' in tasks:
+        num_classes = len(standard_head_settings['particletype']['class_names'])
+        logit = fully_connect(inputs,
+            standard_head_settings['particletype']['fc_head'],
+            expected_logits_dimension=num_classes,
+            name='particle')
+        logits['particletype'] = tf.keras.layers.Softmax(name='particletype')(logit)
+        #logits['particletype'] = tf.keras.utils.to_categorical(logit, num_classes=num_classes)
+        losses['particletype'] = tf.keras.losses.CategoricalCrossentropy(reduction=tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE)
+        loss_weights['particletype'] = standard_head_settings['particletype']['weight']
+        metrics['particletype'] = [
+              tf.keras.metrics.CategoricalAccuracy(name='accuracy'),
+              tf.keras.metrics.Precision(name='precision'),
+              tf.keras.metrics.Recall(name='recall'),
+              tf.keras.metrics.AUC(name='auc'),
+              tf.keras.metrics.AUC(name='prc', curve='PR'), # precision-recall curve
+        ]
+    if 'energy' in tasks:
+        logits['energy'] = fully_connect(inputs,
+            standard_head_settings['energy']['fc_head'],
+            expected_logits_dimension=1,
+            name='energy')
+        losses['energy'] = tf.keras.losses.MeanAbsoluteError(reduction=tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE)
+        loss_weights['energy'] = standard_head_settings['energy']['weight']
+        metrics['energy'] = tf.keras.metrics.MeanAbsoluteError(name='mae_energy')
+    if 'direction' in tasks:
+        logits['direction'] = fully_connect(inputs,
+            standard_head_settings['direction']['fc_head'],
+            expected_logits_dimension=2,
+            name='direction')
+        losses['direction'] = tf.keras.losses.MeanAbsoluteError(reduction=tf.keras.losses.Reduction.SUM_OVER_BATCH_SIZE)
+        loss_weights['direction'] = standard_head_settings['direction']['weight']
+        metrics['direction'] = tf.keras.metrics.MeanAbsoluteError(name='mae_direction')
+
+    # Temp fix till keras support class weights for multiple outputs or I wrote custom loss
+    # https://github.com/keras-team/keras/issues/11735
+    if len(tasks)==1:
+        logits = logits[tasks[0]]
+        losses = losses[tasks[0]]
+        loss_weights = loss_weights[tasks[0]]
+        metrics = metrics[tasks[0]]
+        
+    return logits, losses, loss_weights, metrics

--- a/ctlearn/default_models/res_net.py
+++ b/ctlearn/default_models/res_net.py
@@ -3,43 +3,32 @@ import sys
 
 import tensorflow as tf
 
-def res_net_model(features, model_params, example_description, training):
-
-    # Reshape inputs into proper dimensions
-    merge_telescopes = model_params['res_net'].get('merge_telescopes', False)
-    if merge_telescopes:
-        # Reshape inputs into proper dimensions
-        for (name, f), d in zip(features.items(), example_description):
-            if name.endswith('images'):
-                telescope_data = tf.reshape(f, [-1, d['shape'][1], d['shape'][2], d['shape'][0]*d['shape'][3]])
-    else:
-        for (name, f), d in zip(features.items(), example_description):
-            if name == 'image':
-                telescope_data = tf.reshape(f, [-1, *d['shape']])
+def res_net_model(data, model_params):
 
     # Load neural network model
     sys.path.append(model_params['model_directory'])
     network_module = importlib.import_module(model_params['res_net']['network']['module'])
     network = getattr(network_module,
                       model_params['res_net']['network']['function'])
+    trainable = model_params['res_net'].get('trainable_backbone', True)
+    resnet_name = model_params['resnet_engine'].get('name', 'ResNet')
 
-    with tf.variable_scope("Network"):
+    x = tf.keras.Input(shape=data.img_shape, name='images')
+    
+    # The original ResNet implementation use this padding, but we pad the images in the ImageMapper.
+    #x = tf.pad(telescope_data, tf.constant([[3, 3], [3, 3]]), name='conv1_pad')
+    init_layer = model_params['res_net'].get('init_layer', False)
+    if init_layer:
+        x = tf.keras.layers.Conv2D(filters=init_layer['filters'], kernel_size=init_layer['kernel_size'],
+                strides=init_layer['strides'], name=resnet_name+'_conv1_conv')(x)
+    #x = tf.pad(x, tf.constant([[1, 1], [1, 1]]), name='pool1_pad')
+    init_max_pool = model_params['res_net'].get('init_max_pool', False)
+    if init_max_pool:
+        x = tf.keras.layers.MaxPool2D(pool_size=init_max_pool['size'],
+                strides=init_max_pool['strides'], name=resnet_name+'_pool1_pool')(x)
 
-       x = telescope_data
-       # The original ResNet implementation use this padding, but we pad the images in the ImageMapper.
-       #x = tf.pad(telescope_data, tf.constant([[3, 3], [3, 3]]), name='conv1_pad')
-       init_layer = model_params['res_net'].get('init_layer', False)
-       if init_layer:
-           x = tf.layers.conv2d(x, filters=init_layer['filters'], kernel_size=init_layer['kernel_size'],
-                    strides=init_layer['strides'], name='conv1_conv')
-       #x = tf.pad(x, tf.constant([[1, 1], [1, 1]]), name='pool1_pad')
-       init_max_pool = model_params['res_net'].get('init_max_pool', False)
-       if init_max_pool:
-           x = tf.layers.max_pooling2d(x, init_max_pool['size'], strides=init_max_pool['strides'], name='pool1_pool')
+    output = network(x, params=model_params, trainable=trainable, name=resnet_name)
+    output = tf.keras.layers.GlobalAveragePooling2D(name=resnet_name+'_global_avgpool')(output)
 
-       output = network(x, params=model_params)
-       output = tf.reduce_mean(output, axis=[1,2], name='global_avgpool')
+    return x, tf.keras.Model(x, output, name=resnet_name)
 
-    if model_params['res_net']['pretrained_weights']:    tf.contrib.framework.init_from_checkpoint(model_params['res_net']['pretrained_weights'],{'Network/':'Network/'})
-
-    return output

--- a/ctlearn/default_models/resnet_engine.py
+++ b/ctlearn/default_models/resnet_engine.py
@@ -1,7 +1,15 @@
 import tensorflow as tf
 from ctlearn.default_models.attention import squeeze_excite_block, channel_squeeze_excite_block, spatial_squeeze_excite_block
 
-def stacked_res_blocks(inputs, params, reuse=None, trainable=True):
+def stacked_res_blocks(inputs, params, trainable=True, name=None):
+    """Function to set up a ResNet.
+    Arguments:
+      input_shape: input tensor shape.
+      params: config parameters for the ResNet engine.
+      trainable: boolean, if weights are trainable or not
+    Returns:
+      Output tensor for the ResNet architecture.
+    """
     # Get custom hyperparameters
     residual_block = params['resnet_engine']['stacked_res_blocks'].get('residual_block', 'bottleneck')
     filters_list = [layer['filters'] for layer in
@@ -10,21 +18,21 @@ def stacked_res_blocks(inputs, params, reuse=None, trainable=True):
             params['resnet_engine']['stacked_res_blocks']['architecture']]
     attention = params.get('attention', None)
 
-    x = stack_fn(inputs, filters_list[0], blocks_list[0], residual_block, stride=1, attention=attention, reuse=reuse, trainable=trainable, name='conv2')
+    x = stack_fn(inputs, filters_list[0], blocks_list[0], residual_block, stride=1, attention=attention, trainable=trainable, name=name+'_conv2')
     for i, (filters, blocks) in enumerate(zip(filters_list[1:], blocks_list[1:])):
-       x = stack_fn(x, filters, blocks, residual_block, attention=attention, reuse=reuse, trainable=trainable, name='conv' + str(i+3))
+       x = stack_fn(x, filters, blocks, residual_block, attention=attention, trainable=trainable, name=name+'_conv' + str(i+3))
     return x
 
-def stack_fn(inputs, filters, blocks, residual_block, stride=2, attention=None, reuse=None, trainable=True, name=None):
-    """A set of stacked residual blocks.
+def stack_fn(inputs, filters, blocks, residual_block, stride=2, attention=None, trainable=True, name=None):
+    """Function to stack residual blocks.
     Arguments:
       inputs: input tensor.
       filters: integer, filters of the bottleneck layer in a block.
       blocks: integer, blocks in the stacked blocks.
       residual_block: string, type of residual block.
       stride: default 2, stride of the first layer in the first block.
-      attention: default None, squeeze excite ratio for the
-          attention mechanism.
+      attention: config parameters for the attention mechanism.
+      trainable: boolean, if weights are trainable or not
       name: string, stack label.
     Returns:
       Output tensor for the stacked blocks.
@@ -34,13 +42,56 @@ def stack_fn(inputs, filters, blocks, residual_block, stride=2, attention=None, 
         'basic': basic_residual_block,
         'bottleneck': bottleneck_residual_block
     }
-    x = res_blocks[residual_block](inputs, filters, stride=stride, attention=attention, reuse=reuse, trainable=trainable, name=name + '_block1')
+    
+    x = res_blocks[residual_block](inputs, filters, stride=stride, attention=attention, trainable=trainable, name=name + '_block1')
     for i in range(2, blocks + 1):
-        x = res_blocks[residual_block](x, filters, conv_shortcut=False, attention=attention, reuse=reuse, trainable=trainable, name=name + '_block' + str(i))
+        x = res_blocks[residual_block](x, filters, conv_shortcut=False, attention=attention, trainable=trainable, name=name + '_block' + str(i))
+        
     return x
 
-def basic_residual_block(inputs, filters, kernel_size=3, stride=1, conv_shortcut=True, attention=None, reuse=None, trainable=True, name=None):
-    """A basic residual block.
+def basic_residual_block(inputs, filters, kernel_size=3, stride=1, conv_shortcut=True, attention=None, trainable=True, name=None):
+    """Function to build a basic residual block.
+    Arguments:
+      inputs: input tensor.
+      filters: integer, filters of the bottleneck layer.
+      kernel_size: default 3, kernel size of the bottleneck layer.
+      stride: default 1, stride of the first layer.
+      conv_shortcut: default True, use convolution shortcut if True,
+          otherwise identity shortcut.
+      attention: config parameters for the attention mechanism.
+      trainable: boolean, if weights are trainable or not
+      name: string, block label.
+    Returns:
+      Output tensor for the residual block.
+    """
+
+    if conv_shortcut:
+        shortcut = tf.keras.layers.Conv2D(filters=filters, kernel_size=1,
+                        strides=stride, trainable=trainable, name=name + '_0_conv')(inputs)
+    else:
+        shortcut = inputs
+
+    x = tf.keras.layers.Conv2D(filters=filters, kernel_size=kernel_size,
+            strides=stride, padding='same', activation=tf.nn.relu, trainable=trainable, name=name + '_1_conv')(inputs)
+    x = tf.keras.layers.Conv2D(filters=filters, kernel_size=kernel_size,
+            padding='same', activation=tf.nn.relu, trainable=trainable, name=name + '_2_conv')(x)
+
+    # Attention mechanism
+    if attention is not None:
+        if attention['mechanism'] == 'Squeeze-and-Excitation':
+            x = squeeze_excite_block(x, attention['ratio'], trainable=trainable, name=name + '_se')
+        elif attention['mechanism'] == 'Channel-Squeeze-and-Excitation':
+            x = channel_squeeze_excite_block(x, attention['ratio'], trainable=trainable, name=name + '_cse')
+        elif attention['mechanism'] == 'Spatial-Squeeze-and-Excitation':
+            x = spatial_squeeze_excite_block(x, trainable=trainable, name=name + '_sse')
+
+    x = tf.keras.layers.Add(name=name + '_add')([shortcut, x])
+    x = tf.keras.layers.ReLU(name=name + '_out')(x)
+    
+    return x
+
+def bottleneck_residual_block(inputs, filters, kernel_size=3, stride=1, conv_shortcut=True, attention=None, trainable=True, name=None):
+    """Function to build a bottleneck residual block.
     Arguments:
       inputs: input tensor.
       filters: integer, filters of the bottleneck layer.
@@ -52,129 +103,32 @@ def basic_residual_block(inputs, filters, kernel_size=3, stride=1, conv_shortcut
           attention mechanism.
       name: string, block label.
     Returns:
-      Output tensor for the residual block.
+      Output tensor for the stacked blocks.
     """
 
-    with tf.variable_scope("Basic_res_block", reuse=reuse):
+    if conv_shortcut:
+        shortcut = tf.keras.layers.Conv2D(filters=4*filters, kernel_size=1,
+                        strides=stride, trainable=trainable, name=name + '_0_conv')(inputs)
+    else:
+        shortcut = inputs
 
-        if conv_shortcut:
-            shortcut = tf.layers.conv2d(inputs, filters=filters, kernel_size=1,
-                           strides=stride, reuse=reuse, trainable=trainable, name=name + '_0_conv')
-        else:
-            shortcut = inputs
+    x = tf.keras.layers.Conv2D(filters=filters, kernel_size=1, strides=stride,
+            activation=tf.nn.relu, trainable=trainable, name=name + '_1_conv')(inputs)
 
-        x = tf.layers.conv2d(inputs, filters=filters, kernel_size=kernel_size,
-                strides=stride, padding='same', activation=tf.nn.relu, reuse=reuse, trainable=trainable, name=name + '_1_conv')
-        x = tf.layers.conv2d(x, filters=filters, kernel_size=kernel_size,
-                padding='same', activation=tf.nn.relu, reuse=reuse, trainable=trainable, name=name + '_2_conv')
+    x = tf.keras.layers.Conv2D(filters=filters, kernel_size=kernel_size,
+            padding='same', activation=tf.nn.relu, trainable=trainable, name=name + '_2_conv')(x)
+    x = tf.keras.layers.Conv2D(filters=4*filters, kernel_size=1, trainable=trainable, name=name + '_3_conv')(x)
 
-        # Attention mechanism
-        if attention is not None:
-            if attention['mechanism'] == 'Squeeze-and-Excitation':
-                x = squeeze_excite_block(x, attention['ratio'], reuse=reuse, trainable=trainable, name=name + '_se')
-            elif attention['mechanism'] == 'Channel-Squeeze-and-Excitation':
-                x = channel_squeeze_excite_block(x, attention['ratio'], reuse=reuse, trainable=trainable, name=name + '_cse')
-            elif attention['mechanism'] == 'Spatial-Squeeze-and-Excitation':
-                x = spatial_squeeze_excite_block(x, reuse=reuse, trainable=trainable, name=name + '_sse')
+    # Attention mechanism
+    if attention is not None:
+        if attention['mechanism'] == 'Squeeze-and-Excitation':
+            x = squeeze_excite_block(x, attention['ratio'], trainable=trainable, name=name + '_se')
+        elif attention['mechanism'] == 'Channel-Squeeze-and-Excitation':
+            x = channel_squeeze_excite_block(x, attention['ratio'], trainable=trainable, name=name + '_cse')
+        elif attention['mechanism'] == 'Spatial-Squeeze-and-Excitation':
+            x = spatial_squeeze_excite_block(x, trainable=trainable, name=name + '_sse')
 
-        x = tf.math.add_n([shortcut, x], name=name + '_add')
-        x = tf.nn.relu(x, name=name + '_out')
-        return x
+    x = tf.keras.layers.Add(name=name + '_add')([shortcut, x])
+    x = tf.keras.layers.ReLU(name=name + '_out')(x)
 
-def bottleneck_residual_block(inputs, filters, kernel_size=3, stride=1, conv_shortcut=True, attention=None, reuse=None, trainable=True, name=None):
-    """A bottleneck residual block.
-    Arguments:
-      inputs: input tensor.
-      filters: integer, filters of the bottleneck layer.
-      kernel_size: default 3, kernel size of the bottleneck layer.
-      stride: default 1, stride of the first layer.
-      conv_shortcut: default True, use convolution shortcut if True,
-          otherwise identity shortcut.
-      squeeze_excite_ratio: default 0, squeeze excite ratio for the
-          attention mechanism.
-      name: string, block label.
-    Returns:
-      Output tensor for the residual block.
-    """
-
-    with tf.variable_scope("Bottleneck_res_block", reuse=reuse):
-
-        if conv_shortcut:
-            shortcut = tf.layers.conv2d(inputs, filters=4*filters, kernel_size=1,
-                           strides=stride, reuse=reuse, trainable=trainable, name=name + '_0_conv')
-        else:
-            shortcut = inputs
-
-        x = tf.layers.conv2d(inputs, filters=filters, kernel_size=1, strides=stride,
-                activation=tf.nn.relu, reuse=reuse, trainable=trainable, name=name + '_1_conv')
-
-        x = tf.layers.conv2d(x, filters=filters, kernel_size=kernel_size,
-                padding='same', activation=tf.nn.relu, reuse=reuse, trainable=trainable, name=name + '_2_conv')
-        x = tf.layers.conv2d(x, filters=4*filters, kernel_size=1,
-                reuse=reuse, trainable=trainable, name=name + '_3_conv')
-
-        # Attention mechanism
-        if attention is not None:
-            if attention['mechanism'] == 'Squeeze-and-Excitation':
-                x = squeeze_excite_block(x, attention['ratio'], reuse=reuse, trainable=trainable, name=name + '_se')
-            elif attention['mechanism'] == 'Channel-Squeeze-and-Excitation':
-                x = channel_squeeze_excite_block(x, attention['ratio'], reuse=reuse, trainable=trainable, name=name + '_cse')
-            elif attention['mechanism'] == 'Spatial-Squeeze-and-Excitation':
-                x = spatial_squeeze_excite_block(x, reuse=reuse, trainable=trainable, name=name + '_sse')
-
-        x = tf.math.add_n([shortcut, x], name=name + '_add')
-        x = tf.nn.relu(x, name=name + '_out')
-        return x
-
-def squeeze_excite_block(inputs, ratio=16, reuse=None, trainable=True, name=None):
-    """ A channel & spatial squeeze-excite block.
-    Arguments:
-      inputs: input tensor.
-      ratio: number of output filters
-      name: string, spatial squeeze-excite block label.
-    returns:
-      Output tensor for the squeeze-excite block.
-    References
-    -   [Squeeze and Excitation Networks](https://arxiv.org/abs/1709.01507)
-    -   [Concurrent Spatial and Channel Squeeze & Excitation in Fully Convolutional Networks](https://arxiv.org/abs/1803.02579)
-    """
-
-    cse = channel_squeeze_excite_block(inputs=inputs, ratio=ratio, reuse=reuse, trainable=trainable, name=name + '_cse')
-    sse = spatial_squeeze_excite_block(inputs=inputs, reuse=reuse, trainable=trainable, name=name + '_sse')
-
-    output = tf.math.add_n([cse, sse], name=name + '_add')
-    return output
-
-def channel_squeeze_excite_block(inputs, ratio=4, reuse=None, trainable=True, name=None):
-    """ A channel-wise squeeze-excite block.
-    Arguments:
-      inputs: input tensor.
-      ratio: number of output filters.
-      name: string, channel squeeze-excite block label.
-    returns:
-      Output tensor for the channel squeeze-excite block.
-    """
-
-    filters = inputs.get_shape().as_list()[-1]
-
-    cse = tf.reduce_mean(inputs, axis=[1,2], keepdims=True, name=name + '_avgpool')
-    cse = tf.layers.dense(cse, units=tf.math.divide(filters,ratio), activation='relu', reuse=reuse, trainable=trainable, name=name + '_1_dense')
-    cse = tf.layers.dense(cse, units=filters, activation='sigmoid', reuse=reuse, trainable=trainable, name=name + '_2_dense')
-
-    output = tf.math.multiply(inputs, cse, name=name + '_mult')
-    return output
-
-def spatial_squeeze_excite_block(inputs, reuse=None, trainable=True, name=None):
-    """ A spatial squeeze-excite block.
-    Arguments:
-      inputs: input tensor.
-      name: string, spatial squeeze-excite block label.
-    returns:
-      Output tensor for the spatial squeeze-excite block.
-    """
-
-    sse = tf.layers.conv2d(inputs, filters=1, kernel_size=1,
-              activation=tf.nn.sigmoid, reuse=reuse, trainable=trainable, name=name + '_spatial_conv')
-
-    output = tf.math.multiply(inputs, sse, name=name + '_mult')
-    return output
+    return x

--- a/ctlearn/utils.py
+++ b/ctlearn/utils.py
@@ -38,25 +38,120 @@ def setup_logging(config, log_dir, debug, log_to_file):
     logger.addHandler(handler)
 
     return logger
+    
+    
+def setup_DL1DataReader(config, mode):
+    # Parse file list or prediction file list
+    if mode in ['train', 'load_only']:
+        if isinstance(config['Data']['file_list'], str):
+            data_files = []
+            with open(config['Data']['file_list']) as f:
+                for line in f:
+                    line = line.strip()
+                    if line and line[0] != "#":
+                        data_files.append(line)
+            config['Data']['file_list'] = data_files
+        if not isinstance(config['Data']['file_list'], list):
+            raise ValueError("Invalid file list '{}'. "
+                             "Must be list or path to file".format(config['Data']['file_list']))
+    else:
+        file_list = config['Prediction']['prediction_file_lists'][config['Prediction']['prediction_label']]
+        if file_list.endswith(".txt"):
+            data_files = []
+            with open(file_list) as f:
+                for line in f:
+                    line = line.strip()
+                    if line and line[0] != "#":
+                        data_files.append(line)
+            config['Data']['file_list'] = data_files
+        elif file_list.endswith(".h5"):
+            config['Data']['file_list'] = [file_list]
+        if not isinstance(config['Data']['file_list'], list):
+            raise ValueError("Invalid prediction file list '{}'. "
+                             "Must be list or path to file".format(file_list))
 
-def compute_class_weights(labels, num_class_examples):
-    logger = logging.getLogger()
-    logger.info("Computing class weights...")
-    total_num = sum(num_class_examples.values())
-    class_weights = []
-    for idx, class_name in enumerate(labels):
-        try:
-            num = num_class_examples[(idx,)]
-            class_inverse_frac = total_num / num
-            class_weights.append(class_inverse_frac)
-        except KeyError:
-            logger.warning("Class '{}' has no examples, unable to "
-                           "calculate class weights".format(class_name))
-            class_weights = [1.0 for l in labels]
-            break
-    logger.info("Class labels: {}".format(labels))
-    logger.info("Class weights: {}".format(class_weights))
-    return class_weights
+    data_format = config.get('Data_format', 'stage1')
+    allow_overwrite = config['Data'].get('allow_overwrite', True)
+    del config['Data']['allow_overwrite']
+    
+    tasks = config['Tasks']
+    transformations = []
+    event_info = []
+    if data_format == 'dl1dh':
+        # Parse list of event selection filters
+        event_selection = {}
+        for s in config['Data'].get('event_selection', {}):
+            s = {'module': 'dl1_data_handler.filters', **s}
+            filter_fn, filter_params = load_from_module(**s)
+            event_selection[filter_fn] = filter_params
+        config['Data']['event_selection'] = event_selection
+
+        # Parse list of image selection filters
+        image_selection = {}
+        for s in config['Data'].get('image_selection', {}):
+            s = {'module': 'dl1_data_handler.filters', **s}
+            filter_fn, filter_params = load_from_module(**s)
+            image_selection[filter_fn] = filter_params
+        config['Data']['image_selection'] = image_selection
+        
+        # Need to check this
+        if 'particletype' in tasks:
+            event_info.append('shower_primary_id')
+            transformations.append({'name': 'ShowerPrimaryID', 'args': {'name': 'particletype', 'particle_id_col_name': 'shower_primary_id'}})
+        if 'energy' in tasks:
+            event_info.append('mc_energy')
+            transformations.append({'name': 'MCEnergy', 'args': {'energy_col_name': 'mc_energy'}})
+        if 'direction' in tasks:
+            event_info.append('alt')
+            event_info.append('az')
+            transformations.append({'name': 'AltAz', 'args': {'alt_col_name': 'alt', 'az_col_name': 'az', 'deg2rad': False}})
+
+    else:
+        if 'particletype' in tasks:
+            event_info.append('true_shower_primary_id')
+            transformations.append({'name': 'ShowerPrimaryID'})
+        if 'energy' in tasks:
+            event_info.append('true_energy')
+            transformations.append({'name': 'MCEnergy'})
+        if 'direction' in tasks:
+            event_info.append('true_alt')
+            event_info.append('true_az')
+            transformations.append({'name': 'DeltaAltAz_fix_subarray'})
+            
+    if allow_overwrite:
+        config['Data']['event_info'] = event_info
+    else:
+        transformations = config['Data'].get('transforms', {})
+    
+    transforms = []
+    # Parse list of Transforms
+    for t in transformations:
+        t = {'module': 'dl1_data_handler.transforms', **t}
+        transform, args = load_from_module(**t)
+        transforms.append(transform(**args))
+    config['Data']['transforms'] = transforms
+
+    # Convert interpolation image shapes from lists to tuples, if present
+    if 'interpolation_image_shape' in config['Data'].get('mapping_settings',{}):
+        config['Data']['mapping_settings']['interpolation_image_shape'] = {k: tuple(l) for k, l in config['Data']['mapping_settings']['interpolation_image_shape'].items()}
+
+
+    # Possibly add additional info to load if predicting to write later
+    if mode == 'predict':
+
+        if 'Prediction' not in config:
+            config['Prediction'] = {}
+
+        if config['Prediction'].get('save_identifiers', False):
+            if 'event_info' not in config['Data']:
+                config['Data']['event_info'] = []
+            config['Data']['event_info'].extend(['event_id', 'obs_id'])
+            if config['Data']['mode'] == 'mono':
+                if 'array_info' not in config['Data']:
+                    config['Data']['array_info'] = []
+                config['Data']['array_info'].append('id')
+
+    return config['Data']
 
 def load_from_module(name, module, path=None, args=None):
     if path is not None and path not in sys.path:
@@ -65,31 +160,3 @@ def load_from_module(name, module, path=None, args=None):
     fn = getattr(mod, name)
     params = args if args is not None else {}
     return fn, params
-
-def log_examples(reader, indices, tasks, subset_name, group_by=None):
-    """ Log the number of examples in each class or combination
-
-    Specify the names of the labels to group by as a sequence with group_by.
-    If group_by is None, group by all labels (default).
-    """
-    logger = logging.getLogger()
-    logger.info("Examples for " + subset_name + ':')
-    logger.info("  Total number: {}".format(len(indices)))
-    labels = list(tasks)
-    if group_by is None:
-        group_by = labels
-    num_class_examples = reader.num_examples(group_by=group_by,
-                                             example_indices=indices)
-    logger.info("  Breakdown by " + ', '.join(labels) + ':')
-    for cls, num in num_class_examples.items():
-        names = []
-        for label, idx in zip(labels, cls):
-            # Value if regression label, else class name if class label
-            if tasks[label].get('class_names') is not None:
-                name = tasks[label]['class_names'][idx]
-            else:
-                name = str(idx)
-            names.append(name)
-        logger.info("    " + ', '.join(names) + ": {}".format(num))
-    logger.info('')
-    return num_class_examples

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -1,13 +1,14 @@
 # conda env create -f environment-gpu.yml
-name: ctlearn
+name: ctlearn_tf2
 channels:
     - anaconda
     - conda-forge
-    - cta-observatory
-    - ctlearn-project
+    #- cta-observatory
+    #- ctlearn-project
+    #- nvidia
 dependencies:
-    - python=3.7
-    - dl1_data_handler=0.10.0
+    - python=3.8
+    #- dl1_data_handler=0.10.0
     - astropy
     - matplotlib
     - numpy
@@ -15,9 +16,14 @@ dependencies:
     - pip
     - pyyaml
     - scikit-learn
+    #- cudatoolkit=11
+    #- cudnn=8
+    #- cupti=11
+    #- cuda-nvcc
     - pip:
-        # TensorFlow-GPU v1.15.3
-        - tensorflow_gpu==1.15.3
+        # TensorFlow-GPU 
+        - tensorflow_gpu
         - pyirf
         - ctaplot
+        - pydot
 

--- a/scripts/run_ctlearn_on_Wilkes3.sh
+++ b/scripts/run_ctlearn_on_Wilkes3.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH -A iris-ip007-GPU
+#SBATCH -p ampere
+#SBATCH --nodes=1
+#SBATCH --mem=24000mb
+#SBATCH --gres=gpu:2
+#SBATCH --output=/home/ir-mien1/rds/rds-iris-ip007/ir-mien1/outs/LSTCam_multigpus_%A_%a.out
+#SBATCH --time=20:00:00
+#SBATCH --array=1234
+
+. /etc/profile.d/modules.sh
+
+module purge
+module load rhel8/default-amp
+module load python/3.8 cuda/11.2 cudnn/8.1_cuda-11.2
+module load miniconda/3
+
+source /home/ir-mien1/.bashrc
+source /home/ir-mien1/anaconda3/bin/activate ctlearn_tf2
+
+config_file=/home/ir-mien1/tf2/ctlearn/config/v_0_6_0_benchmarks/LSTCam_TRN_lowcut.yml
+/home/ir-mien1/anaconda3/envs/ctlearn_tf2/bin/python3 /home/ir-mien1/anaconda3/envs/ctlearn_tf2/bin/ctlearn $config_file -l /home/ir-mien1/rds/rds-iris-ip007/ir-mien1/logs/LSTCam_multigpus/ -t particletype --log_to_file --mode train -s $SLURM_ARRAY_TASK_ID
+


### PR DESCRIPTION
This is a PR draft for the CTLearn v0.6.0 using Keras with the latest TensorFlow v.2.7.

**ToDos**:
- [ ] Handle the data loader with Keras functionality. Previous data loader handler `input_fn()`  should be replaced with a Keras batch generator.
- [ ] Upgrade monoscopic models
- [ ] Upgrade stereoscopic models
- [ ] Enable usage of multiple GPUs via `tf.distribute.MirroredStrategy`
- [ ] Save only the best model checkpoints
- [ ] Calculate the class weights in the init of the DL1DH reader and apply always the class weights for the classification task
- [ ] Upgrade the yaml environment file. Try to install CUDA 11.X in the environment from Nvidia conda. Update dependencies like DL1DH and ctapipe to Python 3.8+.
- [ ] Set the reconstruction tasks from command line. Automatise the selection of labels and their transformations.
- [ ] Plot model architecture
