### PR TITLE
Set energy label shape to (batch_size, label_shape)

### DIFF
--- a/ctlearn/data_loader.py
+++ b/ctlearn/data_loader.py
@@ -142,7 +142,7 @@ class KerasBatchGenerator(tf.keras.utils.Sequence):
                 labels['particletype'] = tf.keras.utils.to_categorical(particletype, num_classes=2)
                 label = tf.keras.utils.to_categorical(particletype, num_classes=2)
             if self.enr_pos is not None:
-                labels['energy'] = energy
+                labels['energy'] = energy.reshape((-1, 1))
                 label = energy
             if self.drc_pos is not None:
                 labels['direction'] = direction


### PR DESCRIPTION
Energy labels had shape (batch_size, ), now it is (batch_size, label_shape), as it is for particle type labels and direction labels.