### PR TITLE
TimeDistributed layer instead custom code for stereo models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: focal
 language: python
 python:
-      - "3.8"
+      - "3.10"
 notifications:
     email:
         on_success: change # default: change

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ necessary package channels, and install CTLearn specified version and its depend
 
 .. code-block:: bash
 
-   CTLEARN_VER=0.6.0
+   CTLEARN_VER=0.6.1
    wget https://raw.githubusercontent.com/ctlearn-project/ctlearn/v$CTLEARN_VER/environment.yml
    conda env create -n [ENVIRONMENT_NAME] -f environment.yml
    conda activate [ENVIRONMENT_NAME]
@@ -69,7 +69,7 @@ Finally, install CTLearn into the new conda environment via pypi:
 .. code-block:: bash
 
    conda activate ctlearn
-   pip install ctlearn==0.6.0
+   pip install ctlearn==0.6.1
 
 or with pip from source:
 

--- a/ctlearn/default_models/single_cnn.py
+++ b/ctlearn/default_models/single_cnn.py
@@ -20,7 +20,6 @@ def single_cnn_model(data, model_params):
         sys.path.append(model_params['model_directory'])
         network_module = importlib.import_module(model_params['network']['module'])
         network = getattr(network_module, model_params['network']['function'])
-        network_input = tf.keras.Input(shape=data.img_shape, name=f'images')
 
         # The original ResNet implementation use this padding, but we pad the images in the ImageMapper.
         #x = tf.pad(telescope_data, tf.constant([[3, 3], [3, 3]]), name='conv1_pad')

--- a/ctlearn/run_model.py
+++ b/ctlearn/run_model.py
@@ -132,7 +132,7 @@ def run_model(config, mode="train", debug=False, log_to_file=False):
         else:
             model = tf.keras.Model(backbone_inputs, logits, name='CTLearn_model')
 
-        if config['Model'].get('plot_model', False):
+        if config['Model'].get('plot_model', True):
             logger.info("  Saving the backbone architecture in '{}/backbone.png'.".format(model_dir))
             tf.keras.utils.plot_model(backbone, to_file=model_dir+'/backbone.png', show_shapes=True, show_layer_names=True)
             logger.info("  Saving the model architecture in '{}/model.png'.".format(model_dir))
@@ -485,6 +485,8 @@ def main():
 
         if 'training_file_list.txt' in os.listdir(config['Logging']['model_directory']):
             config['Data']['file_list'] = training_file_list
+
+        config['Data']['example_identifiers_file'] = f"{config['Logging']['model_directory']}/example_identifiers_file.h5"
 
         run_model(config, mode='train', debug=args.debug, log_to_file=args.log_to_file)
 

--- a/ctlearn/run_model.py
+++ b/ctlearn/run_model.py
@@ -132,7 +132,7 @@ def run_model(config, mode="train", debug=False, log_to_file=False):
         else:
             model = tf.keras.Model(backbone_inputs, logits, name='CTLearn_model')
 
-        if config['Model'].get('plot_model', True):
+        if config['Model'].get('plot_model', False):
             logger.info("  Saving the backbone architecture in '{}/backbone.png'.".format(model_dir))
             tf.keras.utils.plot_model(backbone, to_file=model_dir+'/backbone.png', show_shapes=True, show_layer_names=True)
             logger.info("  Saving the model architecture in '{}/model.png'.".format(model_dir))

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
     - cta-observatory
     - ctlearn-project
 dependencies:
-    - python=3.8
+    - python=3.10
     - dl1_data_handler=0.10.6
     - astropy
     - matplotlib


### PR DESCRIPTION
- I wasn't aware of the TimeDistributed keras layer, which does the same thing as the custom code before. Therefore the code is much cleaner with the Keras layer doing the work in the background. 
- dump/read example identifiers from file as default