### PR TITLE
Bug fix in build_irf

### DIFF
--- a/ctlearn/build_irf.py
+++ b/ctlearn/build_irf.py
@@ -407,7 +407,7 @@ def main():
     gammas["selected"] = gammas["selected_theta"] & gammas["selected_gh"]
 
     # scale relative sensitivity by Crab flux to get the flux sensitivity
-    spectrum = particles[1]["target_spectrum"]
+    spectrum = particles[0]["target_spectrum"]
     sensitivity["flux_sensitivity"] = sensitivity["relative_sensitivity"] * spectrum(
         sensitivity["reco_energy_center"]
     )

--- a/ctlearn/build_irf.py
+++ b/ctlearn/build_irf.py
@@ -150,8 +150,13 @@ def main():
         default=0.2,
     )
     parser.add_argument(
-        "--max_bg_radius",
-        help="Maximum background radius in deg; default is 1.0",
+        "--fov_offset_min",
+        help="Minimum distance from the fov center for background events to be taken into account; default is 0.0",
+        default=0.0,
+    )
+    parser.add_argument(
+        "--fov_offset_min",
+        help="Maximum distance from the fov center in deg for background events to be taken into account; default is 1.0",
         default=1.0,
     )
     parser.add_argument(
@@ -203,7 +208,8 @@ def main():
     ALPHA = args.alpha
 
     # Radius to use for calculating bg rate
-    MAX_BG_RADIUS = args.max_bg_radius * u.deg
+    FOV_OFFSET_MIN = args.fov_offset_min * u.deg
+    FOV_OFFSET_MAX = args.fov_offset_max * u.deg
     MAX_GH_CUT_EFFICIENCY = args.max_gh_cut_eff
     GH_CUT_EFFICIENCY_STEP = args.gh_cut_eff_step
 
@@ -390,7 +396,8 @@ def main():
         op=operator.ge,
         theta_cuts=theta_cuts,
         alpha=ALPHA,
-        background_radius=MAX_BG_RADIUS,
+        fov_offset_min=FOV_OFFSET_MIN,
+        fov_offset_max=FOV_OFFSET_MAX,
     )
 
     # now that we have the optimized gh cuts, we recalculate the theta

--- a/environment.yml
+++ b/environment.yml
@@ -21,4 +21,4 @@ dependencies:
         - tensorflow>=2.9,<2.10
         - tf2onnx>=1.12
         - pydot
-        - pyirf>=0.7
+        - pyirf>=0.8


### PR DESCRIPTION
The flux sensitivity was wrongly scaled with the electron spectrum instead of the Crab. This bug was recently introduced by changing the particle id convention to the official CTA one (gamma:0; electron:1 and proton:101). So none of the published results are affected.