### PR TITLE
update date and repo URL in CodeMeta

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -51,10 +51,10 @@
     ],
     "language": "eng",
     "license": "BSD-3-Clause",
-    "publication_date": "2018-03-18",
+    "publication_date": "2022-11-25",
     "related_identifiers": [
         {
-            "identifier": "git+https://github.com/ctlearn-project/ctlearn.git",
+            "identifier": "https://github.com/ctlearn-project/ctlearn",
             "relation": "isDerivedFrom",
             "resource_type": "software",
             "scheme": "url"

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,7 +4,7 @@
     "license": "https://spdx.org/licenses/BSD-3-Clause",
     "codeRepository": "git+https://github.com/ctlearn-project/ctlearn.git",
     "contIntegration": "https://github.com/ctlearn-project/ctlearn/actions",
-    "datePublished": "2018-03-18",
+    "datePublished": "2022-11-25",
     "dateModified": "2022-11-25",
     "downloadUrl": "https://zenodo.org/record/5947837/files/ctlearn-project/ctlearn-v0.7.0.zip",
     "issueTracker": "https://github.com/ctlearn-project/ctlearn/issues",

--- a/codemeta.json
+++ b/codemeta.json
@@ -2,7 +2,7 @@
     "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
     "@type": "SoftwareSourceCode",
     "license": "https://spdx.org/licenses/BSD-3-Clause",
-    "codeRepository": "git+https://github.com/ctlearn-project/ctlearn.git",
+    "codeRepository": "https://github.com/ctlearn-project/ctlearn",
     "contIntegration": "https://github.com/ctlearn-project/ctlearn/actions",
     "datePublished": "2022-11-25",
     "dateModified": "2022-11-25",


### PR DESCRIPTION
More accurate description that will then be reflected in the Zenodo record
(e.g. see publication date in https://zenodo.org/record/6842323 )