### PR TITLE
Added Exceptions to Handle Non-Existent Directories

### DIFF
--- a/ctlearn/build_irf.py
+++ b/ctlearn/build_irf.py
@@ -235,6 +235,9 @@ def main():
     n_showers_factor = 1
     for input in args.input:
         abs_file_dir = os.path.abspath(input)
+        # Exception handling for the input directory
+        if not os.path.isdir(abs_file_dir):
+            raise NotADirectoryError(f"'{abs_file_dir}' is not a directory.")
         for pattern in args.pattern:
             files = glob.glob(os.path.join(abs_file_dir, pattern))
             if not files:

--- a/ctlearn/run_model.py
+++ b/ctlearn/run_model.py
@@ -652,6 +652,9 @@ def main():
         if args.input:
             for input in args.input:
                 abs_file_dir = os.path.abspath(input)
+                # Exception handling for the input directory
+                if not os.path.isdir(abs_file_dir):
+                    raise NotADirectoryError(f"'{abs_file_dir}' is not a directory.")
                 with open(training_file_list, "a") as file_list:
                     for pattern in args.pattern:
                         files = glob.glob(os.path.join(abs_file_dir, pattern))
@@ -683,6 +686,9 @@ def main():
         if args.input:
             for input in args.input:
                 abs_file_dir = os.path.abspath(input)
+                # Exception handling for the input directory
+                if not os.path.isdir(abs_file_dir):
+                    raise NotADirectoryError(f"'{abs_file_dir}' is not a directory.")
                 for pattern in args.pattern:
                     files = glob.glob(os.path.join(abs_file_dir, pattern))
                     if not files:


### PR DESCRIPTION
This Pull Request introduces exceptions that allow handling the issue of non-existent directories in two key scripts:

- `build_irf.py`: During the IRF construction, exceptions are now thrown when directories are missing, allowing for better error handling.
- `run_model.py`: In the model training and testing phases, similar exceptions are thrown when the necessary directories are not found.

These changes ensure that missing directories are detected early and handled properly, avoiding strange errors in the dl1 library.
