### PR TITLE
Focal length choice from subarray of the reader in predict model tool

### DIFF
--- a/ctlearn/tools/predict_model.py
+++ b/ctlearn/tools/predict_model.py
@@ -724,7 +724,7 @@ class PredictCTLearnModel(Tool):
         camera_frame = CameraFrame(
             focal_length=self.dl1dh_reader.subarray.tel[
                 tel_id
-            ].optics.equivalent_focal_length,
+            ].geometry.frame.focal_length,
             rotation=self.dl1dh_reader.pix_rotation[tel_id],
             telescope_pointing=tel_pointing,
         )

--- a/ctlearn/tools/predict_model.py
+++ b/ctlearn/tools/predict_model.py
@@ -724,7 +724,7 @@ class PredictCTLearnModel(Tool):
         camera_frame = CameraFrame(
             focal_length=self.dl1dh_reader.subarray.tel[
                 tel_id
-            ].geometry.frame.focal_length,
+            ].camera.geometry.frame.focal_length,
             rotation=self.dl1dh_reader.pix_rotation[tel_id],
             telescope_pointing=tel_pointing,
         )


### PR DESCRIPTION
Take focal length from the subarray of the reader for the predict model tool. Focal length can be set by reader via 'focal_length_choice'; default is effective.